### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,7 +4,7 @@ author = Mohamed Rashad <mrashad74@gmail.com>
 maintainer = Mohamed Rashad <mrashad74@gmail.com>
 sentence = The first Z80 emulation library for Arduino.
 paragraph = Near-to-complete emulation of software and hardware functions, capable of running z80 assembly, main and extended sets.
-category = other
+category = Other
 url = https://github.com/MohammedRashad/ArduZ80
 architectures = *
 


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'other' in library ArduZ80 is not valid. Setting to
'Uncategorized'
```
on every compilation. The Arduino library specification lists the valid category
values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format